### PR TITLE
hotfix/all-visitors-subdomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Initial release.
+
+## [0.1.2] - 2020-09-15
+### Fixed
+
+- Fix subdomain for all visitors setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix subdomain for all visitors setting
+- Update the README.md file with missing configuration (docs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ It is possible to install the Cookie Script in your store either by using App St
 
 ## Cookie Script Configuration
 
-On the *Cookie scanner* tab, run a scan. After the scan is complete, go to *Cookies* tab and make sure the following cookies are categorized as "Stricly Necessary": ASPXAUTH, checkout.vtex.com, CookieConsent, device, vtex_segment, vtex_session, VtexFingerPrint, VtexRCMacIdv7, VtexRCRequestCounter, VtexRCSessionIdv7, VtexWorkspace;
+On the *Cookie scanner* tab, run a scan. After the scan is complete, go to *Cookies* tab and make sure the following cookies are categorized as "Stricly Necessary": ASPXAUTH, checkout.vtex.com, CookieConsent, device, vtex_segment, vtex_session, VtexFingerPrint, VtexRCMacIdv7, VtexRCRequestCounter, VtexRCSessionIdv7 and VtexWorkspace.
 
 <!-- DOCS-IGNORE:start -->
 ## Contributors ✨

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Cookie Script first party integration app. The [solution](https://cookie-script.
 
 ![image](https://user-images.githubusercontent.com/284515/86488877-d35b0f80-bd38-11ea-95f9-7610985e19d5.png)
 
-## Configuration
+## Vtex Configuration
 
 It is possible to install the Cookie Script in your store either by using App Store or the VTEX IO Toolbelt.
 
@@ -29,6 +29,10 @@ It is possible to install the Cookie Script in your store either by using App St
 2. Access the **Apps** section in your account's admin page and look for the Cookie Script box. Once you find it, click on it.
 3. Fill in the **Cookie Script ID** field.
 4. Click on **Save**.
+
+## Cookie Script Configuration
+
+On the *Cookie scanner* tab, run a scan. After the scan is complete, go to *Cookies* tab and make sure the following cookies are categorized as "Stricly Necessary": ASPXAUTH, checkout.vtex.com, CookieConsent, device, vtex_segment, vtex_session, VtexFingerPrint, VtexRCMacIdv7, VtexRCRequestCounter, VtexRCSessionIdv7, VtexWorkspace;
 
 <!-- DOCS-IGNORE:start -->
 ## Contributors ✨

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
         "type": "string",
         "default": "eu",
         "enum": [
-          "chs03",
+          "cdn",
           "eu",
           "ca",
           "ca-eu"


### PR DESCRIPTION
**What problem is this solving?**

It looks like the subdomain used for the "All Visitors" setting has been updated. They are now using "cdn" instead of "chs03", like could be seen on the image below.

![Screen Shot 2020-09-15 at 19 07 38](https://user-images.githubusercontent.com/5032844/93271346-67aa0f80-f789-11ea-93d1-641ec614d685.png)

**How should this be manually tested?**

Access any page on [this workspace](https://lgpd--polishop.myvtex.com/) and look at the console for the broken request.

![Screen Shot 2020-09-15 at 16 09 56](https://user-images.githubusercontent.com/5032844/93271486-c40d2f00-f789-11ea-826a-7ac77c235d7a.png)
#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
